### PR TITLE
Fix: Adiciona hash de script inline para index.html na CSP

### DIFF
--- a/novo-site/backend/app.js
+++ b/novo-site/backend/app.js
@@ -36,7 +36,8 @@ app.use(helmet({
         "https://cdn.jsdelivr.net",
         "https://cdn.datatables.net",
         "https://cdnjs.cloudflare.com",
-        "https://code.jquery.com"
+        "https://code.jquery.com",
+        "'sha256-/JQ63pWYde98RInTtdPS/CuLs8FJ3+tJHEA3/FKUc+U='" // Hash para script inline em index.html
       ],
       // Adicionando script-src-attr para os handlers onclick
       // Idealmente, estes onlick seriam movidos para event listeners em JS


### PR DESCRIPTION
Complementa o commit anterior adicionando o hash SHA256 necessário para um script inline em index.html à diretiva scriptSrc da Content Security Policy.

Isso visa corrigir o erro de CSP que impedia o carregamento da página principal após os ajustes iniciais na CSP para administracao.html.