### PR TITLE
Fix: Update CSP with final hashes for administracao.html

### DIFF
--- a/novo-site/backend/app.js
+++ b/novo-site/backend/app.js
@@ -45,13 +45,12 @@ app.use(helmet({
         "'sha256-q/qn3w3Qs/CNAZZ5fzowHaEhlWteyigYml/z2rYJJXc='", // script controles nav em home.html
         // "'sha256-BMDcFQYigfMZ1XBbjdo6vgOxomS/mJTSQUzT0mkhAs4='",  // Removido - Duplicata/Antigo para script da linha 79 home.html
 
-        // Hashes para scripts inline em administracao.html - ATUALIZADOS CONFORME ÚLTIMO FEEDBACK
-        "'sha256-1nFBCSxPi4yzm5aO3ZmG54qHI6yzbC+4lv88H2s0rPY='", // linha 207 (toggleSection, Charts)
-        "'sha256-FEyIzOdPXqr98LQlVejYXew9U5OiwfXlTd809VLqp3M='", // linha 215 (módulo layout/auth)
-        "'sha256-zIxNOUOaMqw5CR90+xQrSXo/lT6YcH0QReDjcmyl1MY='", // linha 262 (outro script de módulo)
-                                                                // Hashes antigos 'sha256-VKH...' e 'sha256-yATv...' para administracao.html foram substituídos pelos acima.
+        // Hashes para scripts inline em administracao.html - ATUALIZADOS (rodada final)
+        "'sha256-o3KPeo6Bns/OS7ra33XMtcYSrNDlvhLyY+0nO3PLbNg='", // Novo hash para script ~linha 249 (toggleSection, Charts)
+        "'sha256-NhvjykiwnB7p10oxDeG68iOdeuluB+fBMutJgZKzOLI='", // Novo hash para script ~linha 315 (módulo principal)
+        // Hashes antigos para administracao.html ('1nFBC...', 'FEyIz...', 'zIxNO...') removidos.
 
-        // Hashes para scripts inline em home.html (continuando)
+        // Hashes para scripts inline em home.html (mantidos)
         "'sha256-mmrIG8b8rg2RPIi9t8jV4lmPxmaLz8tH4OADQnidrMQ='",   // script de cards em home.html (linha 95)
         "'sha256-9ZJDv7tjnvA85pGJvzn+1k1jDpaGnVpoWvaJrAvFgF8='"    // script que define navigateTo, logout, getUserPermissions em home.html (linha 79)
       ],


### PR DESCRIPTION
- Add the two correct SHA256 hashes for the remaining inline scripts in administracao.html (toggleSection/Charts block and main module script) to the CSP 'script-src' directive.
- Remove previous/incorrect hashes for administracao.html.

This is the final attempt to fix the CSP and ReferenceError errors
  in administracao.html, allowing the page to function as expected.