### PR TITLE
Fix: Corrigir link 'Início' na página de administração

### DIFF
--- a/novo-site/frontend/pages/administracao.html
+++ b/novo-site/frontend/pages/administracao.html
@@ -21,7 +21,7 @@
 
   <nav class="top-navbar">
     <ul class="nav">
-      <li class="nav-item"><a class="nav-link" href="../index.html#hero">Início</a></li>
+      <li class="nav-item"><a class="nav-link" href="home.html">Início</a></li>
       <li class="nav-item"><a class="nav-link" href="visualizadoridividual.html">Perfil</a></li>
       <li class="nav-item"><a class="nav-link" href="userdados.html">Usuários</a></li>
       <li class="nav-item"><a class="nav-link" href="usinascadastro.html">Cadastro Usina</a></li>


### PR DESCRIPTION
O link 'Início' na barra de navegação superior da página administracao.html agora redireciona para 'home.html' (página principal da área autenticada) em vez de '../index.html#hero'.